### PR TITLE
Use Session objects with app and user parameters

### DIFF
--- a/dvidtools/__init__.py
+++ b/dvidtools/__init__.py
@@ -1,8 +1,8 @@
 # This code is part of dvid-tools (https://github.com/flyconnectome/dvid_tools)
 # and is released under GNU GPL3
 
-__version__ = (0, 1, 8)
-__verstr__ = "0.1.8"
+__version__ = (0, 1, 9)
+__verstr__ = "0.1.9"
 
 from .fetch import *
 from .tip import *


### PR DESCRIPTION
All dvid endpoints permit `u` (user) and `app` parameters.  For example:

```
GET .../api/server/info?u=bergs&app=dvidtools
```

Technically, these parameters are optional (they're only used for logging), but we strongly prefer that all users provide them.

This PR replaces all calls to `requests.get(...)` with `dvid_session().get(...)`, where `dvid_session()` returns a (cached) `requests.Session` object.  That `Session` object is initialized to include those two parameters with every request.  Since `Session` objects are not thread-safe, `dvid_session()` will return a unique `Session` for each calling thread.

Additionally, since the session is cached, your calls reuse the connection to dvid.  Otherwise, some calls may fail to establish a connection to dvid, if you make thousands of calls in quick succession.  This usually only happens when you are really putting a heavy load on dvid, e.g. from hundreds of cores in a compute cluster.
